### PR TITLE
Prevent fail2ban from filling eventlog on every poll

### DIFF
--- a/includes/polling/applications/fail2ban.inc.php
+++ b/includes/polling/applications/fail2ban.inc.php
@@ -94,7 +94,7 @@ if (empty($f2b['jails'])) {
     $f2bc[$id]['label'] = 'Fail2ban Jails';
     $jails = array_keys($f2b['jails']);
     sort($jails);
-    $f2bc[$id]['jails'] = json_encode($jails);
+    $f2bc[$id]['jails'] = json_encode(array_values($jails));
 
     $component->setComponentPrefs($device_id, $f2bc);
 }


### PR DESCRIPTION
Either the jails in the array or the respective indexes get rearranged on every poll. Adding only the values (jail names) without the indexes solves the issue. I tried also asort() which gives the same behavior.

Details: https://community.librenms.org/t/eventlog-filling-with-fail2ban-jail-component-logs-since-latest-stable-update/7902/10

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
